### PR TITLE
fix: pull request URL is /pull not /pulls

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 function extractIssueReferenceFromUrl(url) {
   url = url.replace('https://github.com/', '');
   url = url.replace('/issues', '');
-  url = url.replace('/pulls', '');
+  url = url.replace('/pull', '');
 
   const hashIndex = url.indexOf("#");
 
@@ -49,7 +49,7 @@ chrome.contextMenus.onClicked.addListener(onClickHandler);
 chrome.runtime.onInstalled.addListener(function() {
   // Create one test item for each context type.
   const contexts = ["page", "selection", "link", "editable", "image", "video", "audio"];
-  const showForPages = ["*://github.com/*/*/issues/*", "*://github.com/*/*/pulls/*"];
+  const showForPages = ["*://github.com/*/*/issues/*", "*://github.com/*/*/pull/*"];
 
   for (let i = 0; i < contexts.length; i++) {
     const context = contexts[i];


### PR DESCRIPTION
Hey @jmosul,

I noticed that the extension wasn't working for Pull Requests.

GitHub is a bit strange with their URL syntax for pull requests:

The main listing page for pull requests is `/pulls` but the individual pull request page is `/pull/:id` (singular).